### PR TITLE
Fix invalid zod schema params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paddle/paddle-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP Server for Paddle Billing",
   "license": "Apache-2.0",
   "repository": "https://github.com/PaddleHQ/paddle-mcp-server",

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -232,19 +232,19 @@ export const listTransactionsParameters = z.object({
     .string()
     .optional()
     .describe("Return entities billed at a specific time. Pass an RFC 3339 datetime string."),
-  "billedAt[LT]": z
+  billedAt_lt: z
     .string()
     .optional()
     .describe("Return entities billed before a specific time. Pass an RFC 3339 datetime string."),
-  "billedAt[LTE]": z
+  billedAt_lte: z
     .string()
     .optional()
     .describe("Return entities billed at or before a specific time. Pass an RFC 3339 datetime string."),
-  "billedAt[GT]": z
+  billedAt_gt: z
     .string()
     .optional()
     .describe("Return entities billed after a specific time. Pass an RFC 3339 datetime string."),
-  "billedAt[GTE]": z
+  billedAt_gte: z
     .string()
     .optional()
     .describe("Return entities billed at or after a specific time. Pass an RFC 3339 datetime string."),
@@ -256,19 +256,19 @@ export const listTransactionsParameters = z.object({
     .string()
     .optional()
     .describe("Return entities created at a specific time. Pass an RFC 3339 datetime string."),
-  "createdAt[LT]": z
+  createdAt_lt: z
     .string()
     .optional()
     .describe("Return entities created before a specific time. Pass an RFC 3339 datetime string."),
-  "createdAt[LTE]": z
+  createdAt_lte: z
     .string()
     .optional()
     .describe("Return entities created at or before a specific time. Pass an RFC 3339 datetime string."),
-  "createdAt[GT]": z
+  createdAt_gt: z
     .string()
     .optional()
     .describe("Return entities created after a specific time. Pass an RFC 3339 datetime string."),
-  "createdAt[GTE]": z
+  createdAt_gte: z
     .string()
     .optional()
     .describe("Return entities created at or after a specific time. Pass an RFC 3339 datetime string."),
@@ -320,19 +320,19 @@ export const listTransactionsParameters = z.object({
     .string()
     .optional()
     .describe("Return entities updated at a specific time. Pass an RFC 3339 datetime string."),
-  "updatedAt[LT]": z
+  updatedAt_lt: z
     .string()
     .optional()
     .describe("Return entities updated before a specific time. Pass an RFC 3339 datetime string."),
-  "updatedAt[LTE]": z
+  updatedAt_lte: z
     .string()
     .optional()
     .describe("Return entities updated at or before a specific time. Pass an RFC 3339 datetime string."),
-  "updatedAt[GT]": z
+  updatedAt_gt: z
     .string()
     .optional()
     .describe("Return entities updated after a specific time. Pass an RFC 3339 datetime string."),
-  "updatedAt[GTE]": z
+  updatedAt_gte: z
     .string()
     .optional()
     .describe("Return entities updated at or after a specific time. Pass an RFC 3339 datetime string."),

--- a/src/toolkit.ts
+++ b/src/toolkit.ts
@@ -9,7 +9,7 @@ class PaddleMCPServer extends McpServer {
   constructor({ apiKey, environment }: { apiKey: string; environment: string }) {
     super({
       name: "paddle",
-      version: "0.0.1",
+      version: "0.1.2",
     });
 
     this._paddle = new PaddleAPI(apiKey, environment);


### PR DESCRIPTION
## Description

The `list_transactions` tool was stopping Agent mode in cursor from working, where it would constantly get the following errors:
```
"We're having trouble connecting to the model provider. This might be temporary - please try again in a moment."
or
"Connection failed. If the problem persists, please check your internet connection or VPN"
```

It turns out this is due to having square brackets in the zod schema for the parameters i.e. `billedAt[GTE]`, weirdly using `4o` as the agent would still work and it worked fine in Claude Desktop. Updating the keys and transforming them in the tool seems to fix this

## Changes
- Add `transformParams` function to convert `base_op` into `base[OP]`
- Update params in list transactions to use the underscore notation