### PR TITLE
(ci): Update to use granular NPM token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+      - name: Configure NPM authentication
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_PADDLE_MCP_SERVER}}
+
       - name: Setup pnpm cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
@@ -75,5 +80,3 @@ jobs:
       - name: Publish to npm
         if: steps.version-check.outputs.exists == 'false'
         run: pnpm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Now uses a granular-scoped NPM token for package publishing
Similar to https://github.com/PaddleHQ/paddle-node-sdk/pull/202