### PR TITLE
Fix date filter parameters not forwarded to Paddle API

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -12,21 +12,18 @@ const paginationData = (collection: PaginatedCollection) => ({
   estimatedTotal: collection.estimatedTotal,
 });
 
-// Transform comparison operator query parameters from underscore format to square bracket format
-// Example: created_at_lt becomes created_at[LT], updated_at_gte becomes updated_at[GTE]
-// Other parameters like customer_id, collection_mode are left unchanged
+// Transform camelCase operator suffixes to bracket notation for the Paddle SDK.
+// Example: createdAtGTE -> createdAt[GTE], billedAtLT -> billedAt[LT]
+// The SDK handles camelCase-to-snake_case conversion internally,
+// but it expects operators in bracket notation: createdAt[GTE], not createdAtGTE.
 const transformParams = (params: Record<string, unknown>) => {
-  const operators = ["lt", "lte", "gt", "gte"];
-  
+  const operatorPattern = /^(.+At)(LTE|LT|GTE|GT)$/;
+
   return Object.entries(params).reduce(
     (acc, [key, value]) => {
-      const parts = key.split("_");
-      const lastPart = parts[parts.length - 1];
-      
-      if (parts.length >= 2 && operators.includes(lastPart)) {
-        const operator = parts.pop()!;
-        const base = parts.join("_");
-        acc[`${base}[${operator.toUpperCase()}]`] = value;
+      const match = key.match(operatorPattern);
+      if (match) {
+        acc[`${match[1]}[${match[2]}]`] = value;
       } else {
         acc[key] = value;
       }


### PR DESCRIPTION
## Problem

Date filter parameters like `createdAtGTE`, `createdAtLTE`, `billedAtGT`, `updatedAtLTE` on `list_transactions` are silently ignored — the Paddle API receives no date filtering and returns results regardless of the specified range.

### Root cause

`transformParams` splits parameter keys by `_` (underscore) to detect operator suffixes. However, the MCP Zod schemas define these parameters in camelCase (`createdAtGTE`, not `created_at_gte`), so the split produces a single-element array and the operator is never detected. The parameters pass through unchanged, and the Paddle SDK ignores unrecognized keys.

## Fix

Replace the underscore-based parsing with a regex that matches camelCase operator suffixes directly:

```
/^(.+At)(LTE|LT|GTE|GT)$/
```

- `createdAtGTE` → `createdAt[GTE]` ✅
- `billedAtLT` → `billedAt[LT]` ✅
- `customerId` → `customerId` (unchanged) ✅

The regex is anchored to `At` before the operator suffix, so it only matches date field patterns and won't produce false positives on non-date parameters.

The SDK handles the remaining `camelCase` → `snake_case` conversion internally (`createdAt[GTE]` → `created_at[GTE]`).

## How to verify

```bash
# Call list_transactions with a narrow date window
# Before fix: returns transactions from outside the window
# After fix: returns only transactions within the window
```

## Scope

Only `list_transactions` is affected — it is the only tool that has date filter parameters in its Zod schema and calls `transformParams`.